### PR TITLE
Fix debugging command line doc

### DIFF
--- a/docs/using/debugging-installs.md
+++ b/docs/using/debugging-installs.md
@@ -10,8 +10,8 @@ The following tips will help you to debug the installation of an Squirrel app.
 If the install of your application doesn't seem to be working, you can explore the behavior by executing the install steps from the command line:
 
 ~~~ps
-C:\user\AppData\Local\MyApp> Update.exe --squirrel-install 1.0.0
-C:\user\AppData\Local\MyApp> Update.exe --squirrel-firstrun
+C:\user\AppData\Local\MyApp> MyApp.exe --squirrel-install 1.0.0
+C:\user\AppData\Local\MyApp> MyApp.exe --squirrel-firstrun
 ~~~
 
 The first cmd should create some shortcuts then immediately exit, then the 2nd one should start your app ([source](https://github.com/Squirrel/Squirrel.Windows/issues/525))


### PR DESCRIPTION
Updated the debugging page to tell people to run the commands against their app exe, and not `Update.exe`.

Update.exe did not seem to work, while running directly against the app did.