### PR TITLE
Port Squirrel.Tool to System.CommandLine

### DIFF
--- a/src/Squirrel.Tool/Squirrel.Tool.csproj
+++ b/src/Squirrel.Tool/Squirrel.Tool.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="17.2.0" />
     <PackageReference Include="NuGet.Protocol" Version="6.3.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a sample of what I had mentioned in issue #111 
Though I believe this is a functional port, this was done to show the library and not something I am trying to get merged.

This leverage the [System.CommandLine library](https://docs.microsoft.com/dotnet/standard/commandline/), rather than Mono.Options for the Squirrel.Tool project (csq). By default this brings in lots of additional features including: 
- Standardized default options (such as `--help` and `--version`)
- Command line tab completion (this does require the user to enable it; but it is done once and then is turned on for all System.CommandLine apps including the dotnet SDK)
- async cancellation support (in this I updated several of the methods to be async rather than using `.GetResult()`)
- Standardized help output (though this can be customized to look anyway you like) 
- and more (you can see the [Microsoft docs](https://docs.microsoft.com/dotnet/standard/commandline/) for deeper dives in these features).

Comparing some behavior changes (I used version 3.0.210-g5f9f594; `dotnet tool install --global csq --version 3.0.210-g5f9f594`)

`csq --help`
```
Squirrel Locator 'csq' 3.0.210+5f9f594 (prerelease)
[INFO]   GET https://api.nuget.org/v3/registration5-gz-semver2/csq/index.json
[INFO]   OK https://api.nuget.org/v3/registration5-gz-semver2/csq/index.json 301ms
csq error: Could not find '.sln'. Specify solution with '--csq-sln=', or specify version of squirrel to use with '--csq-version='.
```

After change:
`\csq.exe --help`
```
Description:

Usage:
  csq [options] [[--] <additional arguments>...]]

Options:
  --csq-version <csq-version>
  --csq-sln, --csq-solution <csq-solution>
  --verbose
  --version                                 Show version information
  -?, -h, --help                            Show help and usage information

Additional Arguments:
  Arguments passed to the application that is being run.
```
A few things worth calling out.
- There is currently no description string being provided; I wasn't sure what would be appropriate for it. Adding one is as simple as passing it to the `RootCommand` constructor.
- There are no descriptions being set for any of the options; again this is as simple as passing them to the `Options<T>` constructor.
- The `<additional arguments>` are then passed along to the Squirrel.CommandLine and are not parsed in this project (making this a much simpler example than doing the Squirrel.CommandLine project.


If this looks interesting to you, I would be happy to continue the discussion or even porting over the Squirrel.CommandLine project.
