### PR TITLE
ref(SimpleWebSource): Fix Release Entry source to work with parameter url

### DIFF
--- a/src/Squirrel/Sources/SimpleWebSource.cs
+++ b/src/Squirrel/Sources/SimpleWebSource.cs
@@ -79,7 +79,7 @@ namespace Squirrel.Sources
             // releaseUri can be a relative url (eg. "MyPackage.nupkg") or it can be an 
             // absolute url (eg. "https://example.com/MyPackage.nupkg"). In the former case
             var sourceBaseUri = Utility.EnsureTrailingSlash(BaseUri);
-            var source = new Uri(sourceBaseUri, releaseUri).ToString();
+            var source = Utility.AppendPathToUri(sourceBaseUri, releaseUri).ToString();
 
             this.Log().Info($"Downloading '{releaseEntry.Filename}' from '{source}'.");
             return Downloader.DownloadFile(source, localFile, progress);


### PR DESCRIPTION
When using a Storage URL with parameters (e.g. Azure Blob Storage) getting the release file (/RELEASES) works perfetly. Unfortunatly the downloading of the package doesnt work because it discards all query parameters while building the URI.
Using the same mechanism as GetReleaseFeed by utilizing the Utility.AppendPathToUri makes it work perfectly with parameterized Urls.