### PR TITLE
Spelling and Pluralization in Commands.cs

### DIFF
--- a/src/Squirrel.CommandLine/Windows/Commands.cs
+++ b/src/Squirrel.CommandLine/Windows/Commands.cs
@@ -99,7 +99,7 @@ namespace Squirrel.CommandLine.Windows
                     // do not allow the creation of packages without a SquirrelAwareApp inside
                     if (!awareExes.Any()) {
                         throw new ArgumentException(
-                            "There are no SquirreAwareApp's in the provided package. Please mark an exe " +
+                            "There are no SquirreAwareApps in the provided package. Please mark an exe " +
                             "as aware using the '-e' argument, or the assembly manifest.");
                     }
 
@@ -134,12 +134,12 @@ namespace Squirrel.CommandLine.Windows
                                  select new { Name = Path.GetFileName(pe.Key), Architecture = arch };
 
                     if (awareExes.Count > 0) {
-                        Log.Info($"There are {awareExes.Count} SquirrelAwareApp's. Binaries will be executed during install/update/uninstall hooks.");
+                        Log.Info($"There are {awareExes.Count} SquirrelAwareApps. Binaries will be executed during install/update/uninstall hooks.");
                         foreach (var pe in peArch) {
                             Log.Info($"  Detected SquirrelAwareApp '{pe.Name}' (arch: {pe.Architecture})");
                         }
                     } else {
-                        Log.Warn("There are no SquirrelAwareApp's. No hooks will be executed during install/update/uninstall. " +
+                        Log.Warn("There are no SquirrelAwareApps. No hooks will be executed during install/update/uninstall. " +
                                  "Shortcuts will be created for every binary in package.");
                     }
 

--- a/src/Squirrel.CommandLine/Windows/Commands.cs
+++ b/src/Squirrel.CommandLine/Windows/Commands.cs
@@ -99,7 +99,7 @@ namespace Squirrel.CommandLine.Windows
                     // do not allow the creation of packages without a SquirrelAwareApp inside
                     if (!awareExes.Any()) {
                         throw new ArgumentException(
-                            "There are no SquirreAwareApps in the provided package. Please mark an exe " +
+                            "There are no SquirrelAwareApps in the provided package. Please mark an exe " +
                             "as aware using the '-e' argument, or the assembly manifest.");
                     }
 


### PR DESCRIPTION
The pluralization of "SquirrelAwareApp" is "SquirrelAwareApps", with no apostrophe.
Pluralizing with an apostrophe is [generally considered improper](https://english.stackexchange.com/questions/55970/plurals-of-acronyms-letters-numbers-use-an-apostrophe-or-not#:~:text=There%20are%20one%20or%20two%20cases%20in%20which,of%20single%20numbers%3A%20Find%20all%20the%20number%207%E2%80%99s.).

Also add an 'l' to "SquirreAwareApps"