### PR TITLE
Fix so that --signParallel uses min/max

### DIFF
--- a/src/Squirrel.CommandLine/SystemCommandLineExtensions.cs
+++ b/src/Squirrel.CommandLine/SystemCommandLineExtensions.cs
@@ -155,7 +155,7 @@ namespace Squirrel.CommandLine
             {
                 for (int i = 0; i < result.Tokens.Count; i++) {
                     if (int.TryParse(result.Tokens[i].Value, out int value)) {
-                        if (value is < 1 or > 1000) {
+                        if (value < minimum || value > maximum) {
                             result.ErrorMessage = $"The value for {result.Token.Value} must be greater than {minimum} and less than {maximum}";
                             break;
                         }


### PR DESCRIPTION
The validator for the --signParallel validator was not using the passed in minimum or maximum. These were set the same so the code was working but this fixes it to make it match.