### PR TITLE
Shortcut names for different environments 

### DIFF
--- a/docs/using/naming.md
+++ b/docs/using/naming.md
@@ -14,6 +14,9 @@ The shortcut name is selected from the first non-null item below:
 3. `[assembly: AssemblyDescription("MyApp")` (from `AssemblyInfo.cs`)
 4. Filename of the Exe (e.g., MyApp)
 
+Note: In some instances it may be preferable to use the package name for the shortcut, in preference to the assembly product name. e.g. When you have the same assembly build repackaged with different configuration files for different environments. 
+In order to switch the order of 1 and 2 above, the IAppTools.CreateShortcutForThisExe and corresponding RemoveShortcutForThisExe have a preferPackageName boolean. This should also be set for the UpdateManager.ApplyReleases call.
+
 ## Local Install location
 
 The local install location is determined by the `id` in the NuGet package metadata.

--- a/docs/using/nuget-package-metadata.md
+++ b/docs/using/nuget-package-metadata.md
@@ -8,7 +8,8 @@ Squirrel uses information from your app's EXE as well as the NuGet package Metad
 * **Id** - name of the application (**warning:** you must **[avoid using spaces and dots](https://github.com/Squirrel/Squirrel.Windows/issues/523)** in the Id).
   * Name of the release packages (e.g., **MyApp**-1.0.0-full.nupkg). 
   * Local installation directory (e.g., `%LocalAppData%\MyApp`).
-* **Title** - used for the name of the application in the Windows Application Uninstaller.
+* **Title** - used for the name of the application in the Windows Application Uninstaller. 
+  * Also used for shortcut name if the AssemblyInfo has no shortcut or the preferPackageName flag is set. 
 * **Version** - version specified in `Properties\Assembly.cs`. 
   * Name of the release package (e.g., MyApp-**1.0.0**-full.nupkg).
   * Version number in the Windows Uninstaller (see screenshot below).

--- a/src/Squirrel/IUpdateManager.cs
+++ b/src/Squirrel/IUpdateManager.cs
@@ -100,22 +100,26 @@ namespace Squirrel
         /// CheckForUpdate</param>
         /// <param name="progress">A Observer which can be used to report Progress - 
         /// will return values from 0-100 and Complete, or Throw</param>
+        /// <param name="preferPackageNameForShortcut">Prefer the package product name, rather than assembly product name, for the shortcut name</param>
         /// <returns>The path to the installed application (i.e. the path where
         /// your package's contents ended up</returns>
-        Task<string> ApplyReleases(UpdateInfo updateInfo, Action<int> progress = null);
+
+        Task<string> ApplyReleases(UpdateInfo updateInfo, Action<int> progress = null, bool preferPackageNameForShortcut = false);
 
         /// <summary>
         /// Completely Installs a targeted app
         /// </summary>
         /// <param name="silentInstall">If true, don't run the app once install completes.</param>
         /// <param name="progress">A Observer which can be used to report Progress - 
+        /// <param name="preferPackageNameForShortcut">Prefer the package product name, rather than assembly product name, for the shortcut name</param>
         /// will return values from 0-100 and Complete, or Throw</param>
-        Task FullInstall(bool silentInstall, Action<int> progress = null);
+        Task FullInstall(bool silentInstall, Action<int> progress = null, bool preferPackageNameForShortcut = false);
 
         /// <summary>
         /// Completely uninstalls the targeted app
         /// </summary>
-        Task FullUninstall();
+        /// <param name="preferPackageNameForShortcut">Prefer the package product name, rather than assembly product name, for the shortcut name</param>
+        Task FullUninstall(bool preferPackageNameForShortcut = false);
 
         /// <summary>
         /// Kills all the executables in the target install directory, excluding
@@ -175,7 +179,8 @@ namespace Squirrel
         /// during app update.</param>
         /// <param name="programArguments">The arguments to code into the shortcut</param>
         /// <param name="icon">The shortcut icon</param>
-        void CreateShortcutsForExecutable(string exeName, ShortcutLocation locations, bool updateOnly, string programArguments, string icon);
+        /// <param name="preferPackageName">Prefer the package product name, rather than assembly product name, for the shortcut name</param>
+        void CreateShortcutsForExecutable(string exeName, ShortcutLocation locations, bool updateOnly, string programArguments, string icon, bool preferPackageName);
 
         /// <summary>
         /// Removes shortcuts created by CreateShortcutsForExecutable
@@ -183,7 +188,8 @@ namespace Squirrel
         /// <param name="exeName">The name of the executable, relative to the
         /// app install directory.</param>
         /// <param name="locations">The locations to install the shortcut</param>
-        void RemoveShortcutsForExecutable(string exeName, ShortcutLocation locations);
+        /// <param name="preferPackageName">Prefer the package product name, rather than assembly product name, for the shortcut name</param>
+        void RemoveShortcutsForExecutable(string exeName, ShortcutLocation locations, bool preferPackageName);
 
         /// <summary>
         /// Sets the AppUserModelID of the current process to match that which was added to the 
@@ -250,24 +256,26 @@ namespace Squirrel
         /// Create a shortcut to the currently running executable at the specified locations. 
         /// See <see cref="IAppTools.CreateShortcutsForExecutable"/> to create a shortcut to a different program
         /// </summary>
-        public static void CreateShortcutForThisExe(this IAppTools This, ShortcutLocation location = ShortcutLocation.Desktop | ShortcutLocation.StartMenu)
+        public static void CreateShortcutForThisExe(this IAppTools This, ShortcutLocation location = ShortcutLocation.Desktop | ShortcutLocation.StartMenu, bool preferPackageName = false)
         {
             This.CreateShortcutsForExecutable(
                 Path.GetFileName(SquirrelRuntimeInfo.EntryExePath),
                 location,
                 Environment.CommandLine.Contains("squirrel-install") == false,
                 null,  // shortcut arguments 
-                null); // shortcut icon
+                null, 
+                preferPackageName); // shortcut icon
         }
 
         /// <summary>
         /// Removes a shortcut for the currently running executable at the specified locations.
         /// </summary>
-        public static void RemoveShortcutForThisExe(this IAppTools This, ShortcutLocation location = ShortcutLocation.Desktop | ShortcutLocation.StartMenu)
+        public static void RemoveShortcutForThisExe(this IAppTools This, ShortcutLocation location = ShortcutLocation.Desktop | ShortcutLocation.StartMenu, bool preferPackageName = false)
         {
             This.RemoveShortcutsForExecutable(
                 Path.GetFileName(SquirrelRuntimeInfo.EntryExePath),
-                location);
+                location, 
+                preferPackageName);
         }
     }
 }

--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -116,16 +116,16 @@ namespace Squirrel
         }
 
         /// <inheritdoc/>
-        public async Task<string> ApplyReleases(UpdateInfo updateInfo, Action<int> progress = null)
+        public async Task<string> ApplyReleases(UpdateInfo updateInfo, Action<int> progress = null, bool preferPackageNameForShortcut = false)
         {
             var applyReleases = new ApplyReleasesImpl(AppDirectory);
             await acquireUpdateLock().ConfigureAwait(false);
 
-            return await applyReleases.ApplyReleases(updateInfo, false, false, progress).ConfigureAwait(false);
+            return await applyReleases.ApplyReleases(updateInfo, false, false, preferPackageNameForShortcut, progress).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
-        public async Task FullInstall(bool silentInstall = false, Action<int> progress = null)
+        public async Task FullInstall(bool silentInstall = false, Action<int> progress = null, bool preferPackageNameForShortcut = false)
         {
             var updateInfo = await CheckForUpdate(intention: UpdaterIntention.Install).ConfigureAwait(false);
             await DownloadReleases(updateInfo.ReleasesToApply).ConfigureAwait(false);
@@ -133,17 +133,17 @@ namespace Squirrel
             var applyReleases = new ApplyReleasesImpl(AppDirectory);
             await acquireUpdateLock().ConfigureAwait(false);
 
-            await applyReleases.ApplyReleases(updateInfo, silentInstall, true, progress).ConfigureAwait(false);
+            await applyReleases.ApplyReleases(updateInfo, silentInstall, true, preferPackageNameForShortcut, progress).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
-        public async Task FullUninstall()
+        public async Task FullUninstall(bool preferPackageNameForShortcut = false)
         {
             var applyReleases = new ApplyReleasesImpl(AppDirectory);
             await acquireUpdateLock().ConfigureAwait(false);
 
             this.KillAllExecutablesBelongingToPackage();
-            await applyReleases.FullUninstall().ConfigureAwait(false);
+            await applyReleases.FullUninstall(preferPackageNameForShortcut).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -168,17 +168,17 @@ namespace Squirrel
         }
 
         /// <inheritdoc/>
-        public void CreateShortcutsForExecutable(string exeName, ShortcutLocation locations, bool updateOnly, string programArguments = null, string icon = null)
+        public void CreateShortcutsForExecutable(string exeName, ShortcutLocation locations, bool updateOnly, string programArguments = null, string icon = null, bool preferPackageName = false)
         {
             var installHelpers = new ApplyReleasesImpl(AppDirectory);
-            installHelpers.CreateShortcutsForExecutable(exeName, locations, updateOnly, programArguments, icon);
+            installHelpers.CreateShortcutsForExecutable(exeName, locations, updateOnly, programArguments, icon, preferPackageName);
         }
 
         /// <inheritdoc/>
-        public void RemoveShortcutsForExecutable(string exeName, ShortcutLocation locations)
+        public void RemoveShortcutsForExecutable(string exeName, ShortcutLocation locations, bool preferPackageName)
         {
             var installHelpers = new ApplyReleasesImpl(AppDirectory);
-            installHelpers.RemoveShortcutsForExecutable(exeName, locations);
+            installHelpers.RemoveShortcutsForExecutable(exeName, locations, preferPackageName);
         }
 
         /// <inheritdoc/>
@@ -330,10 +330,10 @@ namespace Squirrel
             return updateProcess;
         }
 
-        internal Dictionary<ShortcutLocation, ShellLink> GetShortcutsForExecutable(string exeName, ShortcutLocation locations, string programArguments = null)
+        internal Dictionary<ShortcutLocation, ShellLink> GetShortcutsForExecutable(string exeName, ShortcutLocation locations, string programArguments = null, bool preferPackageName = false)
         {
             var installHelpers = new ApplyReleasesImpl(AppDirectory);
-            return installHelpers.GetShortcutsForExecutable(exeName, locations, programArguments);
+            return installHelpers.GetShortcutsForExecutable(exeName, locations, programArguments, preferPackageName);
         }
 
         private static string GetLocalAppDataDirectory(string assemblyLocation = null)

--- a/src/Update/StartupOption.cs
+++ b/src/Update/StartupOption.cs
@@ -21,6 +21,7 @@ namespace Squirrel.Update
         internal string shortcutArgs { get; private set; } = default(string);
         internal bool shouldWait { get; private set; } = false;
         internal bool onlyUpdateShortcuts { get; private set; } = false;
+        internal bool preferPackageNameForShortcut { get; private set; } = false;
         internal bool checkInstall { get; private set; } = false;
         internal bool silentInstall { get; private set; } = false;
 
@@ -53,6 +54,7 @@ namespace Squirrel.Update
                 { "i=|icon", "Path to an ICO file that will be used for icon shortcuts", v => icon = v},
                 { "l=|shortcut-locations=", "Comma-separated string of shortcut locations, e.g. 'Desktop,StartMenu'", v => shortcutArgs = v},
                 { "updateOnly", "Update shortcuts that already exist, rather than creating new ones", _ => onlyUpdateShortcuts = true},
+                { "preferPackageNameForShortcut", "Prefer the package product name, rather than exe product name, for the shortcut name", _ => preferPackageNameForShortcut = true},
 
                 // hidden arguments, used internally by Squirrel and should not be used by Squirrel applications themselves
                 { "install=", "Install the app whose package is in the specified directory or url", v => { updateAction = UpdateAction.Install; target = v; }, true },


### PR DESCRIPTION
This adds a preferPackageName flag for shortcut creation and removal, to allow for situations where you want to use the package name in preference to the executable product name. e.g. repackaging same assembly with different config file for different environments.
Resolves #164   

I made the change in master because I needed a working build, but I can also merge into the develop branch if you're happy with it.