### PR TITLE
Fixed GetDownloadUrl always retrieving WindowsDesktop and not the RuntimeType

### DIFF
--- a/src/Squirrel/RuntimeInfo.cs
+++ b/src/Squirrel/RuntimeInfo.cs
@@ -300,7 +300,7 @@ namespace Squirrel
                     _ => throw new ArgumentOutOfRangeException(nameof(CpuArchitecture)),
                 };
 
-                return GetDotNetDownloadUrl(DotnetRuntimeType.WindowsDesktop, latest, architecture);
+                return GetDotNetDownloadUrl(RuntimeType, latest, architecture);
             }
 
             private static Regex _dotnetRegex = new Regex(@"^net(?:coreapp)?(?<version>[\d\.]{1,7})(?:-(?<arch>[\w\d]+))?(?:-(?<type>\w+))?$", RegexOptions.IgnoreCase | RegexOptions.Compiled);


### PR DESCRIPTION
Fixed GetDotnetDownloadUrl not receiving the correct RuntimeType as parameter.

_Note that GetLatestDotNetVersion should still be fixed for WindowsDesktop as it is the only url that the azure blob responds with the latest version. This doesn't matter as all dotnet needed runtimes will have the same latest version._